### PR TITLE
Fix SBOM submission action pin

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -115,6 +115,6 @@ jobs:
       # https://github.com/advanced-security/spdx-dependency-submission-action
       - name: Upload SBOM to Dependency Graph
         if: ${{ github.event_name != 'pull_request' }}
-        uses: advanced-security/spdx-dependency-submission-action@5530bab9ee4bbe66420ce8c8c344acf5c3b8f70d  # v0.1.1
+        uses: advanced-security/spdx-dependency-submission-action@f957edbb35161c1f9e33f61026fc86a671c58cae  # v0.1.2
         with:
           filePath: sbom.spdx.json


### PR DESCRIPTION
## Summary\n- update the SPDX dependency submission action pin to v0.1.2\n- unblock Docker workflow fetch error for the SBOM submission step\n\n## Testing\n- actionlint .github/workflows/docker-publish.yml (fails: existing shellcheck SC2086 on line 100)\n\nCloses #18