### PR TITLE
fix: stabilize Docker workflow runner load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Project overview
+
+- This repository publishes the `opencpu-psychometrics` Docker image.
+- The critical verification path is the Docker build in
+  `.github/workflows/docker-publish.yml`.
+
+## Build and test commands
+
+- Docker regression checks: `python3 -m unittest discover -s tests -v`
+- Local image build probe:
+  `docker build --progress=plain -t opencpu-psychometrics .`
+
+## Code style
+
+- Keep Dockerfile changes focused on build reliability and image behavior.
+- Preserve Ubuntu/OpenCPU/CRAN sources unless there is evidence they
+  are the failure source.
+
+## Documentation
+
+- Update `ARCHITECTURE.md` when the Docker build behavior or workflow
+  expectations change.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,30 @@
+# Architecture
+
+## Overview
+
+This repository ships a single Docker image for
+`ghcr.io/seonghobae/opencpu-psychometrics`.
+The image layers Ubuntu, OpenCPU, system libraries, Rust, and a
+large R package set used for psychometrics workloads.
+GitHub Actions verifies the repository by building and publishing
+that image from `.github/workflows/docker-publish.yml`.
+
+## Build Pipeline
+
+1. `.github/workflows/docker-publish.yml` runs
+   `docker/build-push-action` on pushes, pull requests, and the
+   nightly schedule.
+2. `Dockerfile` installs Ubuntu packages, OpenCPU from the official
+   PPA, the CRAN apt repository, and the required R ecosystem
+   packages.
+3. The workflow signs published images and uploads an SBOM when the
+   event is not a pull request.
+
+## Stability Constraints
+
+- The hosted GitHub runner is the limiting environment for the Docker
+  build.
+- The R package installation layer is capped with `R_INSTALL_NCPUS=2`
+  to reduce peak runner load during `docker/build-push-action`.
+- `BiocManager::install(..., update = FALSE)` is used to avoid a full
+  Bioconductor update sweep during nightly builds.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
+ARG R_INSTALL_NCPUS=2
+ENV R_INSTALL_NCPUS=${R_INSTALL_NCPUS}
 WORKDIR /app
 
 # SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -19,7 +21,7 @@ RUN localedef -f UTF-8 -i ko_KR ko_KR.UTF-8
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 
-RUN R -e "options('install.packages.compile.from.source' = 'never'); options(timeout=100000); options(repos = 'https://cloud.r-project.org'); install.packages('BiocManager', dependencies = TRUE, quiet = TRUE, Ncpus = parallel::detectCores()); BiocManager::install(ask = F, quiet = TRUE, Ncpus = parallel::detectCores()); BiocManager::install('miniCRAN',ask = F, quiet = TRUE, Ncpus = parallel::detectCores()); BiocManager::install(miniCRAN::pkgDep(c('psych','sqldf','pbapply', 'mirt', 'plyr', 'GDINA', 'edina', 'ggplot2', 'lpSolveAPI', 'lavaan', 'stm', 'future.apply', 'openxlsx', 'writexl', 'readxl', 'ctv', 'LMest', 'httr', 'stringr', 'jsonlite', 'progressr')), ask = F, dependencies = T, quiet = TRUE, Ncpus = parallel::detectCores()); ctv::install.views(c('Psychometrics', 'MixedModels'), ask = F, dependencies = T, quiet = TRUE, Ncpus = parallel::detectCores())"
+RUN R -e "options('install.packages.compile.from.source' = 'never'); options(timeout = 100000); options(repos = 'https://cloud.r-project.org'); options(Ncpus = as.integer(Sys.getenv('R_INSTALL_NCPUS'))); install.packages('BiocManager', dependencies = TRUE, quiet = TRUE); BiocManager::install('miniCRAN', ask = FALSE, update = FALSE, quiet = TRUE); BiocManager::install(miniCRAN::pkgDep(c('psych', 'sqldf', 'pbapply', 'mirt', 'plyr', 'GDINA', 'edina', 'ggplot2', 'lpSolveAPI', 'lavaan', 'stm', 'future.apply', 'openxlsx', 'writexl', 'readxl', 'ctv', 'LMest', 'httr', 'stringr', 'jsonlite', 'progressr')), ask = FALSE, update = FALSE, dependencies = TRUE, quiet = TRUE); ctv::install.views(c('Psychometrics', 'MixedModels'), ask = FALSE, update = FALSE, dependencies = TRUE, quiet = TRUE)"
 
 EXPOSE 8004
 CMD ["/bin/bash", "-c", "service ntpsec start && service unattended-upgrades start && service opencpu-server start && service rstudio-server start && service rstudio-server start && R"]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [![Docker](https://github.com/seonghobae/opencpu-psychometrics/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/seonghobae/opencpu-psychometrics/actions/workflows/docker-publish.yml)
 
-The unofficial fork of opencpu-server with Pre-installed Psychometrics libraries in R; A personal project created for use in a company project.
+The unofficial fork of opencpu-server with pre-installed
+psychometrics libraries in R; a personal project created for use in a
+company project.
 
-- Newly built with official Ubuntu 22.04 Docker image and PPA source of the OpenCPU-server.
+- Newly built with official Ubuntu 24.04 Docker image and PPA source of the OpenCPU-server.
 - Just Removed barrier of timeout limits for psychometrics libraries.
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The unofficial fork of opencpu-server with pre-installed
 psychometrics libraries in R; a personal project created for use in a
 company project.
 
-- Newly built with official Ubuntu 24.04 Docker image and PPA source of the OpenCPU-server.
-- Just Removed barrier of timeout limits for psychometrics libraries.
+- Build stability improved by limiting R install parallelism (`R_INSTALL_NCPUS=2`)
+  and disabling Bioconductor update sweeps (`update = FALSE`).
 
 ## Notes
 

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -1,0 +1,32 @@
+import pathlib
+import unittest
+
+DOCKERFILE = pathlib.Path(__file__).resolve().parents[1] / "Dockerfile"
+
+
+class DockerfileBuildStabilityTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.content = DOCKERFILE.read_text(encoding="utf-8")
+
+    def test_r_package_install_does_not_use_all_detected_cores(self) -> None:
+        self.assertNotIn("parallel::detectCores()", self.content)
+        self.assertIn("ARG R_INSTALL_NCPUS=2", self.content)
+        self.assertIn("Sys.getenv('R_INSTALL_NCPUS')", self.content)
+
+    def test_bioconductor_install_disables_global_updates(self) -> None:
+        install_statements = [
+            statement.strip()
+            for statement in self.content.split(";")
+            if "BiocManager::install(" in statement
+        ]
+        self.assertTrue(
+            install_statements, "expected BiocManager::install call in Dockerfile"
+        )
+        self.assertTrue(
+            all("update = FALSE" in statement for statement in install_statements),
+            "expected every BiocManager::install call to pin update = FALSE",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cap Docker image R package installation concurrency with `R_INSTALL_NCPUS=2`
- disable broad Bioconductor update sweeps during image builds to reduce nightly runner load
- add a Dockerfile regression test and document the updated build stability assumptions

<!-- coderabbit_walkthrough_start -->
<!-- walkthrough_start -->
<details open>
<summary>📝 Walkthrough</summary>


## Walkthrough

Dockerfile의 R 패키지 설치 프로세스에서 병렬 처리 CPU 수 제어를 추가하고, 프로젝트 개요 및 아키텍처 문서를 작성하며, 빌드 안정성을 검증하는 테스트를 추가했습니다.

## Changes

|Cohort / File(s)|Summary|
|---|---|
|**문서 및 가이드** <br> `AGENTS.md`, `ARCHITECTURE.md`, `README.md`|프로젝트 개요, 아키텍처 설명, 빌드/테스트 명령 및 코드 스타일 지침을 문서화했습니다. README는 Ubuntu 버전 및 포맷을 업데이트했습니다.|
|**Docker 빌드 구성** <br> `Dockerfile`|`ARG R_INSTALL_NCPUS` 추가로 빌드 시간 CPU 수 제어를 도입했으며, `parallel::detectCores()` 대신 환경 변수 `Sys.getenv('R_INSTALL_NCPUS')`를 사용하도록 R 패키지 설치 스크립트를 변경했습니다.|
|**테스트** <br> `tests/test_dockerfile.py`|Dockerfile의 병렬 처리 제어 및 BiocManager 설치 동작 안정성을 검증하는 단위 테스트를 추가했습니다.|

## Estimated code review effort

🎯 3 (Moderate) | ⏱️ ~20 minutes

## Poem

> 🐰 문서와 코드 함께 자라고,  
> CPU 수는 이제 제어하고,  
> 테스트로 안정성 지키니,  
> 빌드는 순하고 복잡하지 않네! ✨

</details>
<!-- walkthrough_end -->
<!-- coderabbit_walkthrough_end -->